### PR TITLE
Premature Changeset Evaluation

### DIFF
--- a/addon/components/form/changeset-form.js
+++ b/addon/components/form/changeset-form.js
@@ -165,10 +165,6 @@ export default Component.extend({
      * @param changeset
      */
     submit(changeset) {
-      // Only submit if something has actually changed.
-      if (!changeset.get('isDirty')) {
-        return false;
-      }
       // Deprecated.
       this.setFormState('pending');
       return this.get('submit').perform(changeset);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-junkdrawer",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -29,7 +29,6 @@
   "devDependencies": {
     "bootstrap": "4.0.0-beta.2",
     "broccoli-asset-rev": "^2.4.5",
-
     "ember-ajax": "^3.0.0",
     "ember-bootstrap": "^1.0.0-rc.5",
     "ember-changeset": "^1.3.0",


### PR DESCRIPTION
Don't judge my changeset man!

Changeset validations don't work with relationships at all, so the changeset isn't marked `dirty` with relationships are added. Since the check on the form submit against submitting clean changesets doesn't actually do anything, I removed it.

Sorry about not pushing up the change for the npm release. The current version on NPM is 0.7.2