### PR TITLE
Added Configurable Params for UI-Box Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ component.hbs:
     Create New Organization
   {{/b.header}}
 
-  {{#b.body paddingSize='0'}}
+  {{#b.body paddingSize=0}}
     {{form.element label="Organization Name" controlType="text" property="name"}}
   {{/b.body}}
 
@@ -101,11 +101,11 @@ component.hbs:
 {{/ui/ui-box}}
 ```
 
-`paddingSize` is configurable for all box components
+`paddingSize` accepts integers `[0 - 5]`  
 `contentAlign` is configurable for header and footer components
-  - accepts `left`, `right`, `center`, and `between`
-  - header has default of left alignment
-  - footer has default of right alignment
+ - accepts `left`, `right`, `center`, and `between`
+   - header defaults to left
+   - footer defaults to right
 
 
 ## Bootstrap Extras

--- a/README.md
+++ b/README.md
@@ -90,18 +90,18 @@ component.hbs:
     Create New Organization
   {{/b.header}}
 
-  {{#b.body classNames="no-padding"}}
+  {{#b.body paddingSize='0'}}
     {{form.element label="Organization Name" controlType="text" property="name"}}
   {{/b.body}}
 
-  {{#b.footer}}
+  {{#b.footer contentAlign='center'}}
     {{bs-button defaultText="Create Organization" pendingText="Saving..." buttonType="submit"}}
   {{/b.footer}}
 
 {{/ui/ui-box}}
 ```
-Set `classNames` to pass modifier classes to the component.
-Set `tagName` to override the component's default element.
+
+
 
 ## Bootstrap Extras
 The great [Ember Bootstrap](http://www.ember-bootstrap.com/) addon provides a lot of great functionality.
@@ -179,7 +179,6 @@ In your ember-cli-build.js:
 | Component  | component:simple-form-group  |
 | Component  | component:table-loader  |
 | Component  | component:thing-list-item  |
-| Component  | component:thing-list  |
 | Component  | component:thing-list  |
 | Component  | component:ui-box  |
 | Component  | compoennt:close-button |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ component.hbs:
 {{/ui/ui-box}}
 ```
 
+`paddingSize` is configurable for all box components
+`contentAlign` is configurable for header and footer components
+  - accepts `left`, `right`, `center`, and `between`
+  - header has default of left alignment
+  - footer has default of right alignment
 
 
 ## Bootstrap Extras

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ component.hbs:
     {{form.element label="Organization Name" controlType="text" property="name"}}
   {{/b.body}}
 
-  {{#b.footer contentAlign='center'}}
+  {{#b.footer justifyContent='center'}}
     {{bs-button defaultText="Create Organization" pendingText="Saving..." buttonType="submit"}}
   {{/b.footer}}
 
@@ -102,10 +102,10 @@ component.hbs:
 ```
 
 `paddingSize` accepts integers `[0 - 5]`  
-`contentAlign` is configurable for header and footer components
- - accepts `left`, `right`, `center`, and `between`
-   - header defaults to left
-   - footer defaults to right
+`justifyContent` is configurable for header and footer components
+ - accepts `start`, `center`, `end`, `between`, and `around`
+   - header defaults to start
+   - footer defaults to end
 
 
 ## Bootstrap Extras

--- a/addon/components/ui/ui-box/ui-box-body.js
+++ b/addon/components/ui/ui-box/ui-box-body.js
@@ -4,6 +4,11 @@ import { computed } from '@ember/object';
 export default Component.extend({
   classNames: ['card-body'],
   classNameBindings: ['paddingClass'],
+
+  /**
+   * Default Padding
+   * @type {Number}
+   */
   paddingSize: 3,
 
   paddingClass: computed('paddingSize', function() {

--- a/addon/components/ui/ui-box/ui-box-body.js
+++ b/addon/components/ui/ui-box/ui-box-body.js
@@ -1,5 +1,13 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+
 
 export default Component.extend({
   classNames: ['card-body'],
+  classNameBindings: ['paddingClass'],
+  paddingSize: '3',
+
+  paddingClass: computed('paddingSize', function() {  
+    return `p-${this.get('paddingSize')}`;
+  }),
 });

--- a/addon/components/ui/ui-box/ui-box-body.js
+++ b/addon/components/ui/ui-box/ui-box-body.js
@@ -1,13 +1,12 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 
-
 export default Component.extend({
   classNames: ['card-body'],
   classNameBindings: ['paddingClass'],
-  paddingSize: '3',
+  paddingSize: 3,
 
-  paddingClass: computed('paddingSize', function() {  
+  paddingClass: computed('paddingSize', function() {
     return `p-${this.get('paddingSize')}`;
   }),
 });

--- a/addon/components/ui/ui-box/ui-box-footer.js
+++ b/addon/components/ui/ui-box/ui-box-footer.js
@@ -3,10 +3,10 @@ import { computed } from '@ember/object';
 
 export default Component.extend({
   classNames: ['card-footer', 'd-flex', 'align-items-center'],
-  classNameBindings: ['alignClass'],
+  classNameBindings: ['justifyContent'],
   contentAlign: 'right',
 
-  alignClass: computed('contentAlign', function() {
+  justifyContent: computed('contentAlign', function() {
     switch(this.get('contentAlign')) {
       case 'right':
         return 'justify-content-end';

--- a/addon/components/ui/ui-box/ui-box-footer.js
+++ b/addon/components/ui/ui-box/ui-box-footer.js
@@ -1,5 +1,21 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
-  classNames: ['card-footer'],
+  classNames: ['card-footer', 'd-flex', 'align-items-center'],
+  classNameBindings: ['alignClass'],
+  contentAlign: 'right',
+
+  alignClass: computed('contentAlign', function() {
+    switch(this.get('contentAlign')) {
+      case 'right':
+        return 'justify-content-end';
+      case 'center':
+        return 'justify-content-center';
+      case 'left':
+        return 'justify-content-start';
+      case 'between':
+        return 'justify-content-between';
+    }
+  }),
 });

--- a/addon/components/ui/ui-box/ui-box-footer.js
+++ b/addon/components/ui/ui-box/ui-box-footer.js
@@ -3,19 +3,15 @@ import { computed } from '@ember/object';
 
 export default Component.extend({
   classNames: ['card-footer', 'd-flex', 'align-items-center'],
-  classNameBindings: ['justifyContent'],
-  contentAlign: 'right',
+  classNameBindings: ['justifyContentClass'],
 
-  justifyContent: computed('contentAlign', function() {
-    switch(this.get('contentAlign')) {
-      case 'right':
-        return 'justify-content-end';
-      case 'center':
-        return 'justify-content-center';
-      case 'left':
-        return 'justify-content-start';
-      case 'between':
-        return 'justify-content-between';
-    }
+  /**
+   * Justify Content
+   * @type {String}
+   */
+  justifyContent: 'end',
+
+  justifyContentClass: computed('justifyContent', function() {
+    return `justify-content-${this.get('justifyContent')}`;
   }),
 });

--- a/addon/components/ui/ui-box/ui-box-header.js
+++ b/addon/components/ui/ui-box/ui-box-header.js
@@ -4,11 +4,11 @@ import { computed } from '@ember/object';
 export default Component.extend({
   tagName: 'h5',
   classNames: ['card-header', 'd-flex', 'align-items-center', 'px-3'],
-  classNameBindings: ['alignClass', 'paddingClass'],
+  classNameBindings: ['justifyContent', 'paddingClass'],
   contentAlign: 'left',
   paddingSize: 3,
 
-  alignClass: computed('contentAlign', function() {
+  justifyContent: computed('contentAlign', function() {
     switch(this.get('contentAlign')) {
       case 'left':
         return 'justify-content-start';

--- a/addon/components/ui/ui-box/ui-box-header.js
+++ b/addon/components/ui/ui-box/ui-box-header.js
@@ -1,6 +1,27 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
   tagName: 'h5',
-  classNames: ['card-header'],
-});
+  classNames: ['card-header', 'd-flex', 'align-items-center', 'px-3'],
+  classNameBindings: ['alignClass', 'paddingClass'],
+  contentAlign: 'left',
+  paddingSize: '3',
+
+  alignClass: computed('contentAlign', function() {
+    switch(this.get('contentAlign')) {
+      case 'left':
+        return 'justify-content-start';
+      case 'center':
+        return 'justify-content-center';
+      case 'right':
+        return 'justify-content-end';
+      case 'between':
+        return 'justify-content-between';
+    }
+  }),
+
+  paddingClass: computed('paddingSize', function() {
+    return `py-${this.get('paddingSize')}`;
+  }),
+  });

--- a/addon/components/ui/ui-box/ui-box-header.js
+++ b/addon/components/ui/ui-box/ui-box-header.js
@@ -6,7 +6,7 @@ export default Component.extend({
   classNames: ['card-header', 'd-flex', 'align-items-center', 'px-3'],
   classNameBindings: ['alignClass', 'paddingClass'],
   contentAlign: 'left',
-  paddingSize: '3',
+  paddingSize: 3,
 
   alignClass: computed('contentAlign', function() {
     switch(this.get('contentAlign')) {

--- a/addon/components/ui/ui-box/ui-box-header.js
+++ b/addon/components/ui/ui-box/ui-box-header.js
@@ -4,24 +4,25 @@ import { computed } from '@ember/object';
 export default Component.extend({
   tagName: 'h5',
   classNames: ['card-header', 'd-flex', 'align-items-center', 'px-3'],
-  classNameBindings: ['justifyContent', 'paddingClass'],
-  contentAlign: 'left',
+  classNameBindings: ['justifyContentClass', 'paddingClass'],
+
+  /**
+   * Justify Content
+   * @type {String}
+   */
+  justifyContent: 'start',
+
+  /**
+   * Default Padding
+   * @type {Number}
+   */
   paddingSize: 3,
 
-  justifyContent: computed('contentAlign', function() {
-    switch(this.get('contentAlign')) {
-      case 'left':
-        return 'justify-content-start';
-      case 'center':
-        return 'justify-content-center';
-      case 'right':
-        return 'justify-content-end';
-      case 'between':
-        return 'justify-content-between';
-    }
+  justifyContentClass: computed('justifyContent', function() {
+    return `justify-content-${this.get('justifyContent')}`;
   }),
 
   paddingClass: computed('paddingSize', function() {
     return `py-${this.get('paddingSize')}`;
   }),
-  });
+});

--- a/addon/templates/table/model-table.hbs
+++ b/addon/templates/table/model-table.hbs
@@ -3,7 +3,7 @@
   <div class="col-md-12">
     {{#ui/ui-box as |b|}}
       {{yield (hash boxHeader=b.header)}}
-      {{#b.body classNames="no-padding"}}
+      {{#b.body paddingSize='0'}}
         {{#if table }}
           {{#light-table
             table

--- a/addon/templates/table/model-table.hbs
+++ b/addon/templates/table/model-table.hbs
@@ -3,7 +3,7 @@
   <div class="col-md-12">
     {{#ui/ui-box as |b|}}
       {{yield (hash boxHeader=b.header)}}
-      {{#b.body paddingSize='0'}}
+      {{#b.body paddingSize=0}}
         {{#if table }}
           {{#light-table
             table


### PR DESCRIPTION
This PR adds the following configurable params for ui-box components:

`paddingSize` - accepted by header, body, and footer 
   - defaults to `3`, translates into class `p-3`

`justifyContent` - accepted by header and footer 
   - defaults to `start` alignment for header 
   - defaults to `end` alignment for footer