### PR TITLE
Update list-provider resetTable 

### DIFF
--- a/addon/components/list-provider.js
+++ b/addon/components/list-provider.js
@@ -82,21 +82,23 @@ export default Component.extend({
     }
   }).restartable(),
 
-  resetTable() {
+  resetTable(loadList) {
     this.setProperties({
       canLoadMore: true,
       page: 1,
     });
     this.get('list').clear();
-    this.get('fetchRecords').perform();
+    if (loadList) {
+      this.get('loadList').perform();
+    }
   },
 
   actions: {
     update(query) {
       this.get('loadList').perform(query);
     },
-    resetTable() {
-      this.resetTable();
+    resetTable(loadList=true) {
+      this.resetTable(loadList);
     }
   }
 

--- a/addon/components/list-provider.js
+++ b/addon/components/list-provider.js
@@ -82,13 +82,13 @@ export default Component.extend({
     }
   }).restartable(),
 
-  resetTable(loadList) {
+  resetTable(reloadData) {
     this.setProperties({
       canLoadMore: true,
       page: 1,
     });
     this.get('list').clear();
-    if (loadList) {
+    if (reloadData) {
       this.get('loadList').perform();
     }
   },
@@ -97,8 +97,8 @@ export default Component.extend({
     update(query) {
       this.get('loadList').perform(query);
     },
-    resetTable(loadList=true) {
-      this.resetTable(loadList);
+    resetTable(reloadData=false) {
+      this.resetTable(reloadData);
     }
   }
 


### PR DESCRIPTION
This updates the `list-provider` `resetTable` method + adds an option to avoid loading the list data. 