### PR TITLE
Modified Property Setting

### DIFF
--- a/addon/components/list-provider.js
+++ b/addon/components/list-provider.js
@@ -1,8 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
-import { oneWay } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import Table from 'ember-light-table';
 import { task } from 'ember-concurrency';
 import { A } from "@ember/array";
 import { assert } from '@ember/debug';

--- a/addon/components/list-provider.js
+++ b/addon/components/list-provider.js
@@ -18,7 +18,6 @@ export default Component.extend({
   sort: 'name',
   recordType: null,
   canLoadMore: true,
-  list: A([]),
   meta: null,
   defaultRecordQuery: null,
 
@@ -28,6 +27,7 @@ export default Component.extend({
     this.setProperties({
       table: null,
       model: A([]),
+      list: A([]),
       canLoadMore: true,
     });
     this.get('loadList').perform()


### PR DESCRIPTION
This moves the `list` property setting into the `didReceiveAttrs` hook to ensure the data is reset when the `list-provider` component is rendered.